### PR TITLE
[#1] Add getGitVersion function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,7 @@ matrix:
   - ghc: 8.4.4
   - ghc: 8.6.5
   - ghc: 8.8.3
-  
-  - ghc: 8.4.4
-    env: STACK_YAML="$TRAVIS_BUILD_DIR/stack-8.4.4.yaml"
-  
-  - ghc: 8.6.5
-    env: STACK_YAML="$TRAVIS_BUILD_DIR/stack-8.6.5.yaml"
-  
+
   - ghc: 8.8.3
     env: STACK_YAML="$TRAVIS_BUILD_DIR/stack.yaml"
 

--- a/app-version.cabal
+++ b/app-version.cabal
@@ -24,7 +24,7 @@ source-repository head
 
 common common-options
   build-depends:       base >= 4.11.1.0 && < 4.14
-  
+
   ghc-options:         -Wall
                        -Wcompat
                        -Widentities
@@ -60,3 +60,4 @@ library
   import:              common-options
   hs-source-dirs:      src
   exposed-modules:     AppVersion
+  build-depends:       githash ^>= 0.1.3

--- a/src/AppVersion.hs
+++ b/src/AppVersion.hs
@@ -10,16 +10,13 @@ module AppVersion
     ( getGitInfo
     ) where
 
-import Control.Exception (throwIO)
-
 import qualified GitHash as Git
 
 
-{- | Extract 'Git.GitInfo' about the current repository.
+{- | Extract 'Git.GitInfo' about the current repository or return
+'Git.GitHashException' in case of any failures.
 -}
-getGitInfo :: IO Git.GitInfo
+getGitInfo :: IO (Either Git.GitHashException Git.GitInfo)
 getGitInfo = Git.getGitRoot "." >>= \case
-    Left err -> throwIO err
-    Right root -> Git.getGitInfo root >>= \case
-        Left err -> throwIO err
-        Right info -> pure info
+    Left err -> pure $ Left err
+    Right root -> Git.getGitInfo root

--- a/src/AppVersion.hs
+++ b/src/AppVersion.hs
@@ -7,9 +7,19 @@ Get your application version
 -}
 
 module AppVersion
-       ( someFunc
-       ) where
+    ( getGitInfo
+    ) where
+
+import Control.Exception (throwIO)
+
+import qualified GitHash as Git
 
 
-someFunc :: IO ()
-someFunc = putStrLn ("someFunc" :: String)
+{- | Extract 'Git.GitInfo' about the current repository.
+-}
+getGitInfo :: IO Git.GitInfo
+getGitInfo = Git.getGitRoot "." >>= \case
+    Left err -> throwIO err
+    Right root -> Git.getGitInfo root >>= \case
+        Left err -> throwIO err
+        Right info -> pure info

--- a/stack-8.4.4.yaml
+++ b/stack-8.4.4.yaml
@@ -1,1 +1,0 @@
-resolver: lts-12.26

--- a/stack-8.6.5.yaml
+++ b/stack-8.6.5.yaml
@@ -1,1 +1,0 @@
-resolver: lts-14.27


### PR DESCRIPTION
Resolves #1

I believe this function will be helpful. It helps to extract Git metadata in IO. Works like this:

```haskell
λ: getGitInfo 
GitInfo
    { _giHash = "7cbb1565ad4555d402c4109f1b88c0b2a43dc3ae"
    , _giBranch = "chshersh/1-Add-getVersion-function"
    , _giDirty = True
    , _giCommitDate = "Wed Mar 18 13:49:05 2020 +0000"
    , _giCommitCount = 1
    , _giFiles =
        [ "/home/shersh/haskell/kowainik/app-version/.git/index"
        , "/home/shersh/haskell/kowainik/app-version/.git/packed-refs"
        ]
    , _giCommitMessage = "Create the project"
    }
```